### PR TITLE
Improve engine modules robustness

### DIFF
--- a/sample_suggestion_engine.py
+++ b/sample_suggestion_engine.py
@@ -48,7 +48,13 @@ def get_latest_tags():
         return [line.split("Tags:", 1)[-1].strip() for line in f if "Tags:" in line][-3:]
 
 def find_latest_session():
-    sessions = sorted([d for d in os.listdir(SESSIONS_DIR) if d.startswith("session_")], reverse=True)
+    """Return the most recent session name if available."""
+    if not os.path.exists(SESSIONS_DIR):
+        return "session_unknown"
+    sessions = sorted(
+        [d for d in os.listdir(SESSIONS_DIR) if d.startswith("session_")],
+        reverse=True,
+    )
     return sessions[0] if sessions else "session_unknown"
 
 def suggest_samples():

--- a/session_identity_engine.py
+++ b/session_identity_engine.py
@@ -8,7 +8,13 @@ SESSIONS_DIR = "./unnamed_record/sessions"
 FRAGMENT_TAGS = "./fragment_index.md"
 
 def find_latest_session():
-    sessions = sorted([d for d in os.listdir(SESSIONS_DIR) if d.startswith("session_")], reverse=True)
+    """Return the latest session identifier and path if available."""
+    if not os.path.exists(SESSIONS_DIR):
+        return None, None
+    sessions = sorted(
+        [d for d in os.listdir(SESSIONS_DIR) if d.startswith("session_")],
+        reverse=True,
+    )
     if not sessions:
         return None, None
     session_id = sessions[0]
@@ -23,10 +29,16 @@ def extract_tags():
     return [line.split("Tags:", 1)[-1].strip() for line in lines[-5:]]
 
 def extract_voice(session_path):
-    txts = sorted([f for f in os.listdir(session_path) if f.startswith("voice_") and f.endswith(".txt")], reverse=True)
+    """Return the latest voice transcription snippet if available."""
+    if not os.path.exists(session_path):
+        return ""
+    txts = sorted(
+        [f for f in os.listdir(session_path) if f.startswith("voice_") and f.endswith(".txt")],
+        reverse=True,
+    )
     if not txts:
         return ""
-    with open(os.path.join(session_path, txts[0]), 'r') as f:
+    with open(os.path.join(session_path, txts[0]), "r") as f:
         return f.read().strip()
 
 def synthesize_identity(voice_snippet, tags):


### PR DESCRIPTION
## Summary
- handle missing session directories in `session_identity_engine`
- handle missing session directories in `sample_suggestion_engine`

## Testing
- `python3 -m py_compile session_identity_engine.py sample_suggestion_engine.py`
- `python3 session_identity_engine.py`
- `python3 sample_suggestion_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_683c7c2234488325aadeee7860c6d32d